### PR TITLE
Update propertybox.c

### DIFF
--- a/gtk/propertybox.c
+++ b/gtk/propertybox.c
@@ -41,14 +41,15 @@ void linphone_gtk_fill_combo_box(GtkWidget *combo, const char **devices, const c
 		unless we fill it with a dummy text.
 		This dummy text needs to be removed first*/
 	}
-
-	for(;*p!=NULL;++p){
-		if ( cap==CAP_IGNORE
-			|| (cap==CAP_CAPTURE && linphone_core_sound_device_can_capture(linphone_gtk_get_core(),*p))
-			|| (cap==CAP_PLAYBACK && linphone_core_sound_device_can_playback(linphone_gtk_get_core(),*p)) ){
-			gtk_combo_box_append_text(GTK_COMBO_BOX(combo),*p);
-			if (selected && strcmp(selected,*p)==0) active=i;
-			i++;
+	if (p != NULL){
+		for(;*p!=NULL;++p){
+			if ( cap==CAP_IGNORE
+				|| (cap==CAP_CAPTURE && linphone_core_sound_device_can_capture(linphone_gtk_get_core(),*p))
+				|| (cap==CAP_PLAYBACK && linphone_core_sound_device_can_playback(linphone_gtk_get_core(),*p)) ){
+				gtk_combo_box_append_text(GTK_COMBO_BOX(combo),*p);
+				if (selected && strcmp(selected,*p)==0) active=i;
+				i++;
+			}
 		}
 	}
 	if (active!=-1)


### PR DESCRIPTION
Fix an issue that would cause the GTK application to crash when opening the properties panel, if the computer did not have a webcam
